### PR TITLE
Feat.HomeView 더보기, 라이딩 고고씽 버튼 화면전환 시 stack 쌓아이는 이슈 수정

### DIFF
--- a/RideThis/View/Home/Coordinator/HomeCoordinator.swift
+++ b/RideThis/View/Home/Coordinator/HomeCoordinator.swift
@@ -11,14 +11,18 @@ class HomeCoordinator: Coordinator {
     }
     
     func start() {
-        let homeVC = HomeView()
+        let homeVC = HomeView(viewModel: HomeViewModel())
         homeVC.coordinator = self
         navigationController.pushViewController(homeVC, animated: false)
     }
     
     func showRecordListView() {
-        tabBarController.selectedIndex = 2 // Assuming RecordView is the third tab
         if let recordNav = tabBarController.viewControllers?[2] as? UINavigationController {
+            tabBarController.selectedIndex = 2
+            if recordNav.topViewController is RecordListView {
+                return
+            }
+            
             let recordCoordinator = RecordCoordinator(navigationController: recordNav, tabBarController: tabBarController)
             childCoordinators.append(recordCoordinator)
             recordCoordinator.showRecordListView()
@@ -26,8 +30,12 @@ class HomeCoordinator: Coordinator {
     }
     
     func showRecordView() {
-        tabBarController.selectedIndex = 2 // Assuming RecordView is the third tab
         if let recordNav = tabBarController.viewControllers?[2] as? UINavigationController {
+            tabBarController.selectedIndex = 2
+            if recordNav.topViewController is RecordView {
+                return
+            }
+            
             let recordCoordinator = RecordCoordinator(navigationController: recordNav, tabBarController: tabBarController)
             childCoordinators.append(recordCoordinator)
             recordCoordinator.start()


### PR DESCRIPTION
### PR 제목
**[Fix] HomeView 화면전환 시 스택 쌓임 이슈 수정**

### PR 설명

#### 변경 사항 (What)
- `HomeView`에서 '더보기' 및 '라이딩 고고씽' 버튼 클릭 시 화면 전환 시 발생하는 네비게이션 스택이 쌓이는 이슈를 수정했습니다.

#### 변경 사유 (Why)
- 사용자가 버튼을 클릭할 때마다 새로운 화면이 네비게이션 스택에 쌓이는 문제가 발생하여, 잘못된 네비게이션 흐름을 방지하고자 이 문제를 해결하였습니다.

#### 테스트 방법 (How to Test)
1. `HomeView`에서 '더보기' 버튼을 클릭합니다.
2. 화면이 정상적으로 전환되고, 뒤로 가기 시 이전 화면으로 정확히 돌아가는지 확인합니다.
3. '라이딩 고고씽' 버튼을 클릭하여 동일한 동작을 확인합니다.
4. 여러 번의 클릭 후 네비게이션 스택이 쌓이지 않음을 확인합니다.
