### PR TITLE
Feat/kyu sang

### DIFF
--- a/RideThis/Protocol/Bluetooth/Bluetooth.swift
+++ b/RideThis/Protocol/Bluetooth/Bluetooth.swift
@@ -1,10 +1,3 @@
-//
-//  Bluetooth.swift
-//  RideThis
-//
-//  Created by SeongKook on 8/30/24.
-//
-
 import Foundation
 
 

--- a/RideThis/Protocol/Device/DeviceProtocol.swift
+++ b/RideThis/Protocol/Device/DeviceProtocol.swift
@@ -1,1 +1,5 @@
 import Foundation
+
+protocol WheelCircumferenceCoordinatorDelegate: AnyObject {
+    func wheelCircumferenceUpdated(_ circumference: Int)
+}

--- a/RideThis/Service/FCMTokenManager.swift
+++ b/RideThis/Service/FCMTokenManager.swift
@@ -1,10 +1,3 @@
-//
-//  FCMTokenManager.swift
-//  RideThis
-//
-//  Created by SeongKook on 9/3/24.
-//
-
 import Foundation
 
 

--- a/RideThis/View/Device/DeviceDetail/Coordinator/DeviceDetailCoordinator.swift
+++ b/RideThis/View/Device/DeviceDetail/Coordinator/DeviceDetailCoordinator.swift
@@ -1,6 +1,6 @@
 import UIKit
 
-class DeviceDetailCoordinator: Coordinator {
+class DeviceDetailCoordinator: Coordinator, WheelCircumferenceCoordinator.WheelCircumferenceCoordinatorDelegate {
     // MARK: - Properties
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
@@ -41,5 +41,21 @@ class DeviceDetailCoordinator: Coordinator {
     /// 루트 뷰로 돌아가기
     func popToRootView() {
         navigationController.popToRootViewController(animated: true)
+    }
+    
+    /// 휠 둘레 설정 화면 표시
+    func showWheelCircumferenceView(currentWheelCircumference: Int? = nil) {
+        let wheelCircumferenceCoordinator = WheelCircumferenceCoordinator(navigationController: navigationController, viewModel: viewModel, currentWheelCircumference: currentWheelCircumference)
+        wheelCircumferenceCoordinator.delegate = self
+        childCoordinators.append(wheelCircumferenceCoordinator)
+        wheelCircumferenceCoordinator.start()
+    }
+    
+    // MARK: - WheelCircumferenceCoordinatorDelegate Methods
+    
+    func wheelCircumferenceUpdated(_ circumference: Int) {
+        if let deviceDetailVC = navigationController.viewControllers.last as? DeviceDetailView {
+            deviceDetailVC.updateWheelCircumference(circumference)
+        }
     }
 }

--- a/RideThis/View/Device/DeviceDetail/DeviceDetailView.swift
+++ b/RideThis/View/Device/DeviceDetail/DeviceDetailView.swift
@@ -131,6 +131,18 @@ class DeviceDetailView: RideThisViewController {
         tableView.estimatedRowHeight = 44
     }
     
+    /// 휠 둘레 선택 화면 표시
+    // 중복된 메서드를 제거하고, 하나의 메서드만 남깁니다.
+    private func presentWheelCircumferenceViewController() {
+        let currentWheelCircumference = viewModel.selectedDevice?.wheelCircumference
+        coordinator?.showWheelCircumferenceView(currentWheelCircumference: currentWheelCircumference)
+    }
+    
+    func updateWheelCircumference(_ circumference: Int) {
+        viewModel.updateWheelCircumference(circumference)
+        wheelCircumferenceTableView.reloadData()
+    }
+    
     // MARK: - ViewModel Binding
     
     private func bindViewModel() {
@@ -250,10 +262,5 @@ extension DeviceDetailView: UITableViewDelegate, UITableViewDataSource {
         }
 
         return cell
-    }
-    
-    /// 휠 둘레 선택 화면 표시
-    private func presentWheelCircumferenceViewController() {
-        coordinator?.showWheelCircumferenceView()
     }
 }

--- a/RideThis/View/Device/DeviceDetail/DeviceDetailView.swift
+++ b/RideThis/View/Device/DeviceDetail/DeviceDetailView.swift
@@ -192,7 +192,7 @@ class DeviceDetailView: RideThisViewController {
 // MARK: - UITableViewDelegate, UITableViewDataSource
 extension DeviceDetailView: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return tableView == deviceInfoTableView ? 4 : 1
+        return tableView == deviceInfoTableView ? 3 : 1
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -221,7 +221,6 @@ extension DeviceDetailView: UITableViewDelegate, UITableViewDataSource {
         let infoData: [(String, String)] = [
             ("이름", device.name),
             ("일련번호", device.serialNumber),
-            ("펌웨어 버전", device.firmwareVersion),
             ("등록 상태", device.registrationStatus ? "등록" : "미등록")
         ]
         

--- a/RideThis/View/Device/DeviceSearch/Coordinator/DeviceSearchCoordinator.swift
+++ b/RideThis/View/Device/DeviceSearch/Coordinator/DeviceSearchCoordinator.swift
@@ -36,7 +36,11 @@ class DeviceSearchCoordinator: Coordinator {
     }
     
     /// 현재 뷰 닫기
-    func dismissView() {
-        navigationController.dismiss(animated: true)
+    func dismissViewAndRefreshDeviceView() {
+        navigationController.dismiss(animated: true) { [weak self] in
+            if let deviceView = self?.navigationController.viewControllers.last as? DeviceView {
+                deviceView.refreshDeviceList()
+            }
+        }
     }
 }

--- a/RideThis/View/Device/DeviceSearch/DeviceSearchView.swift
+++ b/RideThis/View/Device/DeviceSearch/DeviceSearchView.swift
@@ -14,7 +14,7 @@ class DeviceSearchView: RideThisViewController {
     private let cancelButton = UIButton(type: .system)
     private let contentView = UIView()
     private let imageView = UIImageView(image: UIImage(named: "deviceSearch"))
-    private let searchingLabel = RideThisLabel(fontType: .sectionTitle, text: "검색중...")
+    private let searchingLabel = RideThisLabel(fontType: .sectionTitle, text: "")
     private let deviceTableView = UITableView(frame: .zero, style: .insetGrouped)
     private var isProcessingSelection = false
     
@@ -151,11 +151,23 @@ class DeviceSearchView: RideThisViewController {
     private func bindViewModel() {
         viewModel.$searchedDevices
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in
+            .sink { [weak self] devices in
                 self?.deviceTableView.reloadData()
+                self?.updateSearchingLabel(devices.isEmpty)
             }
             .store(in: &cancellables)
     }
+    
+    /// 검색 상태에 따라 검색 레이블의 텍스트를 업데이트하는 메서드
+    /// - Parameter isEmpty: 기기 목록이 비어 있는지 여부를 나타내는 Bool 값
+    private func updateSearchingLabel(_ isEmpty: Bool) {
+        if isEmpty {
+            searchingLabel.text = "검색중..."
+        } else {
+            searchingLabel.text = "케이던스 기기를 선택해주세요"
+        }
+    }
+
 }
 
 // MARK: - UITableViewDelegate, UITableViewDataSource

--- a/RideThis/View/Device/DeviceSearch/DeviceSearchView.swift
+++ b/RideThis/View/Device/DeviceSearch/DeviceSearchView.swift
@@ -141,7 +141,7 @@ class DeviceSearchView: RideThisViewController {
     /// 버튼 액션 설정
     private func setupActions() {
         cancelButton.addAction(UIAction { [weak self] _ in
-            self?.coordinator?.dismissView()
+            self?.coordinator?.dismissViewAndRefreshDeviceView()
         }, for: .touchUpInside)
     }
     
@@ -194,7 +194,7 @@ extension DeviceSearchView: UITableViewDelegate, UITableViewDataSource {
                 do {
                     try await viewModel.addDeviceWithDefaultSettings(selectedDevice)
                     DispatchQueue.main.async {
-                        self.coordinator?.dismissView()
+                        self.coordinator?.dismissViewAndRefreshDeviceView()
                     }
                 } catch {
                     print("Error adding device: \(error)")
@@ -205,12 +205,10 @@ extension DeviceSearchView: UITableViewDelegate, UITableViewDataSource {
             self.viewModel.addDeviceUnkownedUser(selectedDevice)
             
             DispatchQueue.main.async {
-                self.coordinator?.dismissView()
+                self.coordinator?.dismissViewAndRefreshDeviceView()
             }
             
             isProcessingSelection = false
         }
-        
-        
     }
 }

--- a/RideThis/View/Device/DeviceView.swift
+++ b/RideThis/View/Device/DeviceView.swift
@@ -142,6 +142,8 @@ class DeviceView: RideThisViewController {
     
     /// 장치 검색 BottomSheet 표시
     private func presentDeviceSearchBottomSheet() {
+        print(UserService.shared.loginStatus)
+        print(UserService.shared.loginStatus == .appleLogin)
         if UserService.shared.loginStatus == .appleLogin {
             // 회원일 경우
             if viewModel.devices.count == 1 {
@@ -164,6 +166,8 @@ class DeviceView: RideThisViewController {
                         }
                     }
                 }
+            } else {
+                coordinator?.showDeviceSearchView()
             }
         } else {
             // 비회원일 경우

--- a/RideThis/View/Device/WheelCircumference/Coordinator/WheelCircumferenceCoordinator.swift
+++ b/RideThis/View/Device/WheelCircumference/Coordinator/WheelCircumferenceCoordinator.swift
@@ -5,28 +5,50 @@ class WheelCircumferenceCoordinator: Coordinator {
     var navigationController: UINavigationController
     var childCoordinators: [Coordinator] = []
     private let viewModel: DeviceViewModel
-    
+    private let currentWheelCircumference: Int?
     
     // MARK: - Initialization
     
     /// WheelCircumferenceCoordinator 초기화
+    /// 이 메서드는 휠의 둘레 값을 선택하는 화면을 관리하는 Coordinator를 초기화합니다.
+    /// 선택한 휠의 둘레 값이 있을 경우, 해당 값을 사용해 초기 설정을 할 수 있습니다.
+    ///
     /// - Parameters:
-    ///   - navigationController: 네비게이션 컨트롤러
-    ///   - viewModel: DeviceViewModel 인스턴스
-    init(navigationController: UINavigationController, viewModel: DeviceViewModel) {
+    ///   - navigationController: 화면 전환을 담당하는 UINavigationController 인스턴스
+    ///   - viewModel: 휠과 관련된 데이터 로직을 관리하는 DeviceViewModel 인스턴스
+    ///   - currentWheelCircumference: 선택된 휠의 둘레 값 (선택 사항, 기본값은 nil)
+    init(navigationController: UINavigationController, viewModel: DeviceViewModel, currentWheelCircumference: Int? = nil) {
         self.navigationController = navigationController
         self.viewModel = viewModel
+        self.currentWheelCircumference = currentWheelCircumference
+    }
+
+    
+    weak var delegate: WheelCircumferenceCoordinatorDelegate?
+        
+        func start() {
+            let wheelCircumferenceVC = WheelCircumferenceView(viewModel: viewModel, currentWheelCircumference: currentWheelCircumference)
+            wheelCircumferenceVC.coordinator = self
+            wheelCircumferenceVC.onCircumferenceSelected = { [weak self] circumference, tireSize in
+                self?.delegate?.wheelCircumferenceUpdated(circumference)
+            }
+            navigationController.pushViewController(wheelCircumferenceVC, animated: true)
+        }
+    
+
+    protocol WheelCircumferenceCoordinatorDelegate: AnyObject {
+        func wheelCircumferenceUpdated(_ circumference: Int)
     }
     
     
     // MARK: - Coordinator Methods
     
     /// 코디네이터 시작: WheelCircumferenceView를 네비게이션 스택에 푸시
-    func start() {
-        let wheelCircumferenceVC = WheelCircumferenceView(viewModel: viewModel)
-        wheelCircumferenceVC.coordinator = self
-        navigationController.pushViewController(wheelCircumferenceVC, animated: true)
-    }
+//    func start() {
+//        let wheelCircumferenceVC = WheelCircumferenceView(viewModel: viewModel, currentWheelCircumference: currentWheelCircumference)
+//        wheelCircumferenceVC.coordinator = self
+//        navigationController.pushViewController(wheelCircumferenceVC, animated: true)
+//    }
     
     /// 현재 뷰에서 뒤로 가기
     func popView() {

--- a/RideThis/View/Device/WheelCircumference/WheelCircumferenceView.swift
+++ b/RideThis/View/Device/WheelCircumference/WheelCircumferenceView.swift
@@ -49,6 +49,17 @@ class WheelCircumferenceView: UIViewController {
         setupBindings()
         setupKeyboardDismiss()
     }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        // 검색 텍스트 필드를 비우고 검색 결과 초기화
+        searchTextField.text = ""
+        viewModel.filterWheelCircumferences(with: "")
+        
+        // 테이블 뷰 리로드
+        tableView.reloadData()
+    }
 
     // MARK: - UI Setup
     

--- a/RideThis/View/Home/AlarmView.swift
+++ b/RideThis/View/Home/AlarmView.swift
@@ -46,7 +46,7 @@ class AlarmView: RideThisViewController {
     }()
     
     private let noAlarmLabel: RideThisLabel = {
-        let label = RideThisLabel(fontType: .defaultSize, fontColor: .gray, text: "알람이 없습니다")
+        let label = RideThisLabel(fontType: .defaultSize, fontColor: .gray, text: "알림이 없습니다")
         label.textAlignment = .center
         label.isHidden = true
         return label
@@ -72,7 +72,7 @@ class AlarmView: RideThisViewController {
     
     /// NavigationBar 설정
     private func setupNavigationBar() {
-        title = "알람 목록"
+        title = "알림 목록"
     }
     
     /// TableView뷰 설정
@@ -87,7 +87,7 @@ class AlarmView: RideThisViewController {
         }
     }
     
-    /// '알람 없음' 라벨 설정
+    /// '알림 없음' 라벨 설정
     private func setupNoAlarmLabel() {
         view.addSubview(noAlarmLabel)
         noAlarmLabel.snp.makeConstraints {
@@ -112,7 +112,7 @@ class AlarmView: RideThisViewController {
         viewModel.fetchAlarmDatas()
     }
     
-    /// 알람 유무에 따라 '알람 없음' 라벨과 테이블 뷰의 가시성 업데이트
+    /// 알림 유무에 따라 '알림 없음' 라벨과 테이블 뷰의 가시성 업데이트
     private func updateNoAlarmLabelVisibility() {
         noAlarmLabel.isHidden = !viewModel.alarams.isEmpty
         alarmTableView.isHidden = viewModel.alarams.isEmpty

--- a/RideThis/View/Home/AlarmView.swift
+++ b/RideThis/View/Home/AlarmView.swift
@@ -3,6 +3,8 @@ import UIKit
 import SnapKit
 import Combine
 
+// MARK: - Enums
+
 enum AlarmCase: String, CaseIterable {
     case follow = "Follow"
     
@@ -16,15 +18,21 @@ enum AlarmCase: String, CaseIterable {
     }
     
     func findCase(str: String) -> Self {
-        return AlarmCase.allCases.filter{ $0.rawValue == str }.first!
+        return AlarmCase.allCases.first { $0.rawValue == str }!
     }
 }
 
+// MARK: - AlarmView
+
 class AlarmView: RideThisViewController {
+    
+    // MARK: - Properties
     
     private let firebaseService = FireBaseService()
     private var cancellable = Set<AnyCancellable>()
     private lazy var viewModel = AlarmViewModel(firebaseService: self.firebaseService)
+    
+    // MARK: - UI Components
     
     private lazy var alarmTableView: UITableView = {
         let table = UITableView()
@@ -34,22 +42,41 @@ class AlarmView: RideThisViewController {
         table.register(AlarmTableViewCell.self, forCellReuseIdentifier: "AlarmTableViewCell")
         table.backgroundColor = .primaryBackgroundColor
         table.separatorStyle = .none
-        
         return table
     }()
+    
+    private let noAlarmLabel: RideThisLabel = {
+        let label = RideThisLabel(fontType: .defaultSize, fontColor: .gray, text: "알람이 없습니다")
+        label.textAlignment = .center
+        label.isHidden = true
+        return label
+    }()
+    
+    // MARK: - Lifecycle Methods
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
         configureUI()
         setCombineData()
+        setupNavigationBar()
     }
     
-    func configureUI() {
+    // MARK: - UI Setup
+    
+    /// UI 구성 요소 설정
+    private func configureUI() {
         setTableView()
+        setupNoAlarmLabel()
     }
     
-    func setTableView() {
+    /// NavigationBar 설정
+    private func setupNavigationBar() {
+        title = "알람 목록"
+    }
+    
+    /// TableView뷰 설정
+    private func setTableView() {
         view.addSubview(alarmTableView)
         
         alarmTableView.snp.makeConstraints {
@@ -60,19 +87,39 @@ class AlarmView: RideThisViewController {
         }
     }
     
-    func setCombineData() {
+    /// '알람 없음' 라벨 설정
+    private func setupNoAlarmLabel() {
+        view.addSubview(noAlarmLabel)
+        noAlarmLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
+        }
+    }
+    
+    // MARK: - Data Binding
+    
+    /// Combine을 사용하여 데이터 바인딩 설정
+    private func setCombineData() {
         viewModel.$alarams
             .receive(on: DispatchQueue.main)
-            .sink { [weak self] alarm in
+            .sink { [weak self] alarms in
                 guard let self = self else { return }
                 
                 self.alarmTableView.reloadData()
+                self.updateNoAlarmLabelVisibility()
             }
             .store(in: &cancellable)
         
         viewModel.fetchAlarmDatas()
     }
+    
+    /// 알람 유무에 따라 '알람 없음' 라벨과 테이블 뷰의 가시성 업데이트
+    private func updateNoAlarmLabelVisibility() {
+        noAlarmLabel.isHidden = !viewModel.alarams.isEmpty
+        alarmTableView.isHidden = viewModel.alarams.isEmpty
+    }
 }
+
+// MARK: - UITableViewDelegate, UITableViewDataSource
 
 extension AlarmView: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
@@ -96,7 +143,6 @@ extension AlarmView: UITableViewDelegate, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        
         let alarm = viewModel.alarams[indexPath.row]
         if !alarm.alarm_status {
             alarm.alarm_status = true

--- a/RideThis/View/Home/Coordinator/HomeCoordinator.swift
+++ b/RideThis/View/Home/Coordinator/HomeCoordinator.swift
@@ -41,4 +41,9 @@ class HomeCoordinator: Coordinator {
             recordCoordinator.start()
         }
     }
+    
+    func showLoginView() {
+        let loginVC = LoginView()
+        self.navigationController.pushViewController(loginVC, animated: true)
+    }
 }

--- a/RideThis/View/Home/HomeView.swift
+++ b/RideThis/View/Home/HomeView.swift
@@ -100,7 +100,7 @@ class HomeView: RideThisViewController {
     }()
     
     private lazy var letsRideButton: RideThisButton = {
-        let button = RideThisButton(buttonTitle: "라이딩 고고씽", height: 50)
+        let button = RideThisButton(buttonTitle: "Let's RideThis", height: 50)
         button.addAction(UIAction { [weak self] _ in
             self?.coordinator?.showRecordView()
         }, for: .touchUpInside)
@@ -115,7 +115,7 @@ class HomeView: RideThisViewController {
     }()
     
     private lazy var weatherTitleLabel: UILabel = {
-        let label = RideThisLabel(fontType: .sectionTitle, fontColor: .black, text: "라이딩하기 따악 좋은 날이고만!")
+        let label = RideThisLabel(fontType: .sectionTitle, fontColor: .black, text: "날씨 정보")
         label.font = UIFont.boldSystemFont(ofSize: label.font.pointSize)
         
         return label
@@ -543,7 +543,8 @@ class HomeView: RideThisViewController {
         weeklyRecordDataView.addArrangedSubview(createRecordItemView(title: "달린 시간", value: model.weeklyRecord.runTime))
         weeklyRecordDataView.addArrangedSubview(createRecordItemView(title: "달린 거리", value: String(format: "%.2f Km", model.weeklyRecord.runDistance)))
         
-        letsRideTitleLabel.text = "\(model.userName)님, 라이딩 고고씽?"
+        let userNickName = model.userName.isEmpty ? "비회원" : model.userName
+        letsRideTitleLabel.text = "\(userNickName)님, Let's RideThis?"
     }
     
     /// 날씨 컨테이너 뷰에 그라디언트 적용

--- a/RideThis/View/Home/HomeView.swift
+++ b/RideThis/View/Home/HomeView.swift
@@ -548,7 +548,7 @@ class HomeView: RideThisViewController {
         weeklyRecordDataView.addArrangedSubview(createRecordItemView(title: "달린 시간", value: model.weeklyRecord.runTime))
         weeklyRecordDataView.addArrangedSubview(createRecordItemView(title: "달린 거리", value: String(format: "%.2f Km", model.weeklyRecord.runDistance)))
         
-        let userNickName = model.userName.isEmpty ? "비회원" : model.userName
+        let userNickName = viewModel.isUserLoggedIn ? model.userName : "비회원"
         letsRideTitleLabel.text = "\(userNickName)님, Let's RideThis?"
     }
     

--- a/RideThis/View/Home/HomeView.swift
+++ b/RideThis/View/Home/HomeView.swift
@@ -507,7 +507,7 @@ class HomeView: RideThisViewController {
         let separator = RideThisSeparator()
         separator.snp.makeConstraints { separator in
             separator.width.equalTo(35)
-            separator.height.equalTo(3)
+            separator.height.equalTo(1)
         }
         
         let weeklyRecordDataSetView = UIStackView(arrangedSubviews: [titleLabel, separator, valueLabel])

--- a/RideThis/View/Home/HomeView.swift
+++ b/RideThis/View/Home/HomeView.swift
@@ -48,7 +48,12 @@ class HomeView: RideThisViewController {
         button.setTitleColor(.primaryColor, for: .normal)
         button.titleLabel?.font = UIFont.systemFont(ofSize: FontCase.smallTitle.rawValue, weight: .regular)
         button.addAction(UIAction { [weak self] _ in
-            self?.coordinator?.showRecordListView()
+            if self?.viewModel.isUserLoggedIn == true {
+                self?.coordinator?.showRecordListView()
+            } else {
+                self?.showLoginAlert()
+            }
+            
         }, for: .touchUpInside)
         return button
     }()
@@ -551,5 +556,16 @@ class HomeView: RideThisViewController {
     private func applyGradientToWeatherContainer() {
         weatherContainer.setGradient(color1: UIColor(red: 12/255, green: 79/255, blue: 146/255, alpha: 1),
                                      color2: UIColor(red: 77/255, green: 143/255, blue: 209/255, alpha: 1))
+    }
+    
+    /// 로그인 필요 알림을 보여주고, 확인 시 로그인 화면으로 이동
+    private func showLoginAlert() {
+        showAlert(
+            alertTitle: "로그인 필요",
+            msg: "기록 목록을 보려면 로그인이 필요합니다. 로그인 하시겠습니까?",
+            confirm: "로그인"
+        ) {
+            self.coordinator?.showLoginView()
+        }
     }
 }

--- a/RideThis/ViewModel/Home/HomeViewModel.swift
+++ b/RideThis/ViewModel/Home/HomeViewModel.swift
@@ -17,6 +17,12 @@ class HomeViewModel: NSObject, CLLocationManagerDelegate {
     private let geocoder = CLGeocoder()
     private let weatherService = WeatherService.shared
     
+    // MARK: - Computed Properties
+    /// 사용자의 로그인 상태를 확인
+    var isUserLoggedIn: Bool {
+        return UserService.shared.loginStatus == .appleLogin
+    }
+    
     // MARK: - Initialization
     override init() {
         let initialWeeklyRecord = HomeModel.WeeklyRecord(runCount: 0, runTime: "0시간 0분", runDistance: 0.0)


### PR DESCRIPTION
### PR 제목
**[Feat/Refactor/Fix] Bluetooth 기기 연결 로직 리팩토링 및 UI 수정**

### PR 설명

#### 변경 사항 (What)
- **Bluetooth 기기 연결 관련 리팩토링**
  - `RecordView` 및 `RecordViewModel`에서 로그인 여부에 따른 Bluetooth 연결 처리 방식을 분리
  - Apple 로그인 사용자와 비로그인 사용자에게 각각 다른 경고 메시지 표시
  - Bluetooth 연결 상태 처리 로직을 비동기로 변경 (`Task` 사용)
  - `Firebase`에서 기기 정보를 가져오는 로직 추가
  - `UserDefaults`에서 기기 정보를 관리하는 방식 수정

- **UI 및 기능 수정**
  - 닉네임이 없을 때 기본 문구 추가
  - 라이딩 고고씽 및 날씨 관련 타이틀 문구 수정
  - 로그인되지 않은 경우 '더보기' 버튼을 누르면 alert 표시
  - 알림이 없을 때 표시될 기본 문구 추가
  - 휠 둘레 선택 및 검색 화면에서 사용성 개선:
    - 선택된 휠 둘레를 테이블뷰에서 스크롤 위치로 표시
    - 휠 둘레 화면으로 돌아올 때 검색창 초기화
  - 블루투스 기기 케이던스 제한 기능 추가

#### 관련 이슈 (Related Issues)
- 비로그인 시 기록을 요약하고 저장했을때 로그인 유도 alert이 뜨는데, 이 때 로그인을 했을떄 HomeView화면으로 이동하는데 기록이 저장되지 않는다. 또 비로그인 유저가 기록 저장 시 로그인했을때 HomeView보다는 해당 기록이 저장된 기록 목록 화면이나 기록화면으로 이동하는게 좋을 것 같다. -> 나 오기전에 수정되어 있으면 좋겠네


