### PR TITLE
Feat/KyuSang

### DIFF
--- a/RideThis/View/Competition/Cell/CompetitionTVCell.swift
+++ b/RideThis/View/Competition/Cell/CompetitionTVCell.swift
@@ -38,20 +38,20 @@ class CompetitionTVCell: UITableViewCell {
     private func setupLayout() {
         numberImage.snp.makeConstraints { image in
             image.top.equalTo(self.contentView.snp.top).offset(10)
-            image.left.equalTo(self.contentView.snp.left).offset(10)
+            image.left.equalTo(self.contentView.snp.left).offset(20)
             image.bottom.equalTo(self.contentView.snp.bottom).offset(-10)
             image.width.equalTo(20)
         }
         
         userNameLabel.snp.makeConstraints { name in
             name.top.equalTo(self.contentView.snp.top).offset(10)
-            name.left.equalTo(numberImage.snp.right).offset(5)
+            name.left.equalTo(numberImage.snp.right).offset(6)
             name.bottom.equalTo(self.contentView.snp.bottom).offset(-10)
         }
         
         timeLabel.snp.makeConstraints { time in
             time.top.equalTo(self.contentView.snp.top).offset(10)
-            time.right.equalTo(self.contentView.snp.right).offset(-10)
+            time.right.equalTo(self.contentView.snp.right).offset(-20)
             time.bottom.equalTo(self.contentView.snp.bottom).offset(-10)
         }
     }

--- a/RideThis/View/Competition/CompetitionView.swift
+++ b/RideThis/View/Competition/CompetitionView.swift
@@ -60,6 +60,9 @@ class CompetitionView: RideThisViewController {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.register(CompetitionTVCell.self, forCellReuseIdentifier: "CompetitionTVCell")
         tableView.rowHeight = 41
+        tableView.layer.cornerRadius = 10
+        tableView.clipsToBounds = true
+            
         
         return tableView
     }()

--- a/RideThis/View/Competition/StartCompetition/StartCompetitionViewController.swift
+++ b/RideThis/View/Competition/StartCompetition/StartCompetitionViewController.swift
@@ -247,7 +247,7 @@ class StartCompetitionViewController: RideThisViewController {
     // MARK: setupAction
     private func setupAction() {
         giveUpBtn.addAction(UIAction { [weak self] _ in
-            self?.showAlert(alertTitle: "경쟁중지", msg: "현재 경쟁기록 진행중입니다. 포기하시겠습니까?", confirm: "포기") {
+            self?.showAlert(alertTitle: "경쟁 포기", msg: "현재 경쟁기록 진행중입니다. 포기하시겠습니까?", confirm: "포기") {
                 self?.coordinator?.popToRootView()
             }
         }, for: .touchUpInside)

--- a/RideThis/View/MyPage/Follow/SearchUserView.swift
+++ b/RideThis/View/MyPage/Follow/SearchUserView.swift
@@ -44,6 +44,11 @@ class SearchUserView: RideThisViewController {
         let cancelButton = UIBarButtonItem(title: "취소", style: .plain, target: self, action: #selector(cancelAction))
         self.navigationItem.leftBarButtonItem = cancelButton
         self.sheetPresentationController?.prefersGrabberVisible = true
+        
+        // 네비게이션 바 아래에 추가 여백 설정
+        if let navigationController = self.navigationController {
+            navigationController.additionalSafeAreaInsets.top = 20 
+        }
     }
     
     func setSearchBar() {

--- a/RideThis/View/Record/RecordCounter/RecordCounterViewController.swift
+++ b/RideThis/View/Record/RecordCounter/RecordCounterViewController.swift
@@ -9,7 +9,7 @@ class RecordCounterViewController: UIViewController {
     private var cancellables = Set<AnyCancellable>()
     
     private let countLabel = RideThisLabel(fontType: .countDownSize, fontColor: .primaryColor, text: "5")
-    private let countInfoLabel = RideThisLabel(fontType: .classification, fontColor: .black, text: "경쟁을 떠나 안전이 최우선입니다.")
+    private let countInfoLabel = RideThisLabel(fontType: .classification, fontColor: .black, text: "기록을 떠나 안전이 최우선입니다.")
 
 
     // MARK: ViewDidLoad


### PR DESCRIPTION
### PR 제목
**[Fix/Feat] 경쟁 관련 UI 및 텍스트 수정, 네비게이션 바 여백 추가**

### PR 설명

#### 변경 사항 (What)
- **텍스트 수정**
  - "경쟁중지"를 "경쟁 포기"로 수정
  - "경쟁을 떠나"를 "기록을 떠나"로 수정

- **UI 수정**
  - 경쟁 테이블에 코너 라디어스를 추가하여 디자인 개선
  - 셀 여백을 수정하여 더 깔끔한 레이아웃 구현

- **네비게이션 바 수정**
  - 네비게이션 바 아래에 추가적인 여백을 설정

#### 테스트 방법 (How to Test)
1. **텍스트 수정 확인**
   - "경쟁 포기"와 "기록을 떠나" 텍스트가 올바르게 표시되는지 확인합니다.

2. **UI 수정 확인**
   - 경쟁 테이블의 코너 라디어스와 셀 여백이 디자인 가이드에 맞게 적용되었는지 확인합니다.
   - 네비게이션 바 하단에 추가된 여백이 의도한 대로 적용되었는지 확인합니다.

3. **종합 테스트**
   - 전체 레이아웃이 변경 사항에 따라 올바르게 표시되는지 테스트합니다.
